### PR TITLE
added unicode escaping

### DIFF
--- a/shellutil/settingsutil.hpp
+++ b/shellutil/settingsutil.hpp
@@ -44,7 +44,44 @@ inline std::string escapeToReadable(const std::string &input) {
     }
     return result.str();
 }
-
+inline char *getUnicodeChar(unsigned int code) {
+    char *chars = new char[5]();
+    if (code <= 0x7F) {
+        chars[0] = (code & 0x7F);
+        chars[1] = '\0';
+    } else if (code <= 0x7FF) {
+        // one continuation byte
+        chars[1] = 0x80 | (code & 0x3F);
+        code = (code >> 6);
+        chars[0] = 0xC0 | (code & 0x1F);
+        chars[2] = '\0';
+    } else if (code <= 0xFFFF) {
+        // two continuation bytes
+        chars[2] = 0x80 | (code & 0x3F);
+        code = (code >> 6);
+        chars[1] = 0x80 | (code & 0x3F);
+        code = (code >> 6);
+        chars[0] = 0xE0 | (code & 0xF);
+        chars[3] = '\0';
+    } else if (code <= 0x10FFFF) {
+        // three continuation bytes
+        chars[3] = 0x80 | (code & 0x3F);
+        code = (code >> 6);
+        chars[2] = 0x80 | (code & 0x3F);
+        code = (code >> 6);
+        chars[1] = 0x80 | (code & 0x3F);
+        code = (code >> 6);
+        chars[0] = 0xF0 | (code & 0x7);
+        chars[4] = '\0';
+    } else {
+        // unicode replacement character
+        chars[2] = 0xEF;
+        chars[1] = 0xBF;
+        chars[0] = 0xBD;
+        chars[3] = '\0';
+    }
+    return chars;
+}
 inline std::string readableToEscape(const std::string &input) {
     std::ostringstream result;
     size_t i = 0;
@@ -52,6 +89,15 @@ inline std::string readableToEscape(const std::string &input) {
         if (input[i] == '\\' && input[i + 1] == 'e') {
             result << '\033';
             i += 2;
+        } else if (input[i] == '\\' && input[i + 1] == 'u') {
+            std::string chars = "";
+            chars += input[i + 2];
+            chars += input[i + 3];
+            chars += input[i + 4];
+            chars += input[i + 5];
+            i += 6;
+            int codepoint = std::stoi(chars, nullptr, 16);
+            result << getUnicodeChar(codepoint);
         } else if (input[i] == '\\' && input[i + 1] == ';') {
             result << ';';
             i += 2;

--- a/shellutil/settingsutil.hpp
+++ b/shellutil/settingsutil.hpp
@@ -98,6 +98,17 @@ inline std::string readableToEscape(const std::string &input) {
             i += 6;
             int codepoint = std::stoi(chars, nullptr, 16);
             result << getUnicodeChar(codepoint);
+        } else if (input[i] == '\\' && input[i + 1] == 'U') {
+            std::string chars = "";
+            chars += input[i+2];
+            chars += input[i+3];
+            chars += input[i+4];
+            chars += input[i+5];
+            chars += input[i+6];
+            chars += input[i+7];
+            i += 8;
+            int codepoint = std::stoi(chars, nullptr, 16);
+            result << getUnicodeChar(codepoint);
         } else if (input[i] == '\\' && input[i + 1] == ';') {
             result << ';';
             i += 2;

--- a/shellutil/settingsutil.hpp
+++ b/shellutil/settingsutil.hpp
@@ -89,23 +89,14 @@ inline std::string readableToEscape(const std::string &input) {
         if (input[i] == '\\' && input[i + 1] == 'e') {
             result << '\033';
             i += 2;
-        } else if (input[i] == '\\' && input[i + 1] == 'u') {
+        } else if (input[i] == '\\' && (input[i + 1] == 'U' || input[i + 1] == 'u')) {
             std::string chars = "";
             chars += input[i + 2];
             chars += input[i + 3];
             chars += input[i + 4];
             chars += input[i + 5];
-            i += 6;
-            int codepoint = std::stoi(chars, nullptr, 16);
-            result << getUnicodeChar(codepoint);
-        } else if (input[i] == '\\' && input[i + 1] == 'U') {
-            std::string chars = "";
-            chars += input[i+2];
-            chars += input[i+3];
-            chars += input[i+4];
-            chars += input[i+5];
-            chars += input[i+6];
-            chars += input[i+7];
+            chars += input[i + 6];
+            chars += input[i + 7];
             i += 8;
             int codepoint = std::stoi(chars, nullptr, 16);
             result << getUnicodeChar(codepoint);


### PR DESCRIPTION
Unicode escaping now works in config theme files!! 

use `\uxxxx` to use a Unicode value